### PR TITLE
Add option to select the timestamp field

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.3.0 (2019-09-24)
+------------------
+
+Add --timestamp option to select the timestamp field to use in the InfluxDB Sink connector.  
+
 0.2.8 (2019-09-16)
 ------------------
 

--- a/connect_manager/__init__.py
+++ b/connect_manager/__init__.py
@@ -24,4 +24,4 @@
 
 __author__ = """Angelo Fausti"""
 __email__ = 'angelofausti@gmail.com'
-__version__ = '0.2.8'
+__version__ = '0.3.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.8
+current_version = 0.3.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/lsst-sqre/kafka-connect-manager',
-    version='0.2.8',
+    version='0.3.0',
     entry_points={
         'console_scripts': ['connect_manager = connect_manager.main:main']
     }


### PR DESCRIPTION
- Select the timestamp field to use when recording messages in
InfluxDB
- The default bevavior is to use sys_time()