### PR TITLE
[DM-23575] Add support to Kafka Replicator connector in kafka-connect-manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+cp-kafka-connect/confluentinc-kafka-connect-replicator*
+*.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3
+FROM python:3.7-slim
 MAINTAINER afausti@lsst.org
 LABEL description="Python client for managing Confluent Kafka connectors" \
       name="lsstsqre/kafka-connect-manager"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.7.0 (2020-03-03)
+------------------
+
+* Add support to replicator connector
+
+* Fix ``tasks.max`` configuration parameter name 
+
 0.6.0 (2020-02-14)
 ------------------
 

--- a/connect_manager/__init__.py
+++ b/connect_manager/__init__.py
@@ -24,4 +24,4 @@
 
 __author__ = """Angelo Fausti"""
 __email__ = 'angelofausti@gmail.com'
-__version__ = '0.6.0'
+__version__ = '0.7.0'

--- a/connect_manager/influxdb_sink.py
+++ b/connect_manager/influxdb_sink.py
@@ -228,7 +228,7 @@ def make_influxdb_sink_config(influxdb_url, database, tasks,
     config = {}
     config['connector.class'] = 'com.datamountaineer.streamreactor.'\
                                 'connect.influx.InfluxSinkConnector'
-    config['task.max'] = tasks
+    config['tasks.max'] = tasks
     config['connect.influx.url'] = influxdb_url
     config['connect.influx.db'] = database
     config['connect.influx.username'] = username

--- a/connect_manager/influxdb_sink.py
+++ b/connect_manager/influxdb_sink.py
@@ -80,9 +80,9 @@ from .utils import (get_broker_url, get_kafka_connect_url,
           '--auto-update does not take effect if --dry-run is used.')
 )
 @click.option(
-    '--check-interval', 'check_interval', default=15,
-    help=('Time interval in seconds to check for new topics and update the '
-          'connector.')
+    '--check-interval', 'check_interval', default=15000,
+    help=('The interval, in milliseconds, to check for new topics and update'
+          'the connector.')
 )
 @click.option(
     '--blacklist', 'blacklist', multiple=True,
@@ -155,7 +155,7 @@ def create_influxdb_sink(ctx, topics, name, influxdb_url, database, tasks,
 
     if auto_update:
         while True:
-            time.sleep(check_interval)
+            time.sleep(int(check_interval) / 1000)
             try:
                 current_topics = get_topics(broker_url, filter_regex,
                                             blacklist)

--- a/connect_manager/main.py
+++ b/connect_manager/main.py
@@ -34,6 +34,7 @@ import requests
 import json
 
 from .influxdb_sink import create_influxdb_sink
+from .replicator import create_replicator
 from .utils import get_kafka_connect_url, get_connector_status
 
 
@@ -247,3 +248,4 @@ def help(ctx, topic, **kw):
 
 # Add subcommands from other modules
 create.add_command(create_influxdb_sink)
+create.add_command(create_replicator)

--- a/connect_manager/replicator.py
+++ b/connect_manager/replicator.py
@@ -1,0 +1,199 @@
+# This file is part of kafka-connect-manager.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Manage the Confluent Replicator connector.
+https://docs.confluent.io/current/connect/kafka-connect-replicator/index.html
+"""
+
+__all__ = ('create_replicator', 'make_replicator_config',)
+
+import click
+import json
+
+from .utils import (get_kafka_connect_url, update_connector,
+                    get_connector_status)
+
+
+@click.command('replicator')
+@click.argument('topics', nargs=-1, required=False)
+@click.option(
+    '--name', 'name', required=False, default='replicator',
+    show_default=True,
+    help='Name of the connector to create.'
+)
+@click.option(
+    '--src-kafka', required=True,
+    nargs=1,
+    help=('A list of host and port pairs to use for establishing the initial '
+          'connection to the source Kafka cluster. This list must be in the '
+          'form `host1:port1,host2:port2,...`.')
+)
+@click.option(
+    '--dest-kafka', required=True, nargs=1,
+    help=('A list of host and port pairs to use for establishing the initial '
+          'connection to the destination Kafka cluster. This list must be in '
+          'the form `host1:port1,host2:port2,...`.')
+)
+@click.option(
+    '--topic-rename-format', default="${topic}",
+    nargs=1, required=False, show_default=True,
+    help='A format string for the topic name in the destination cluster, '
+         'which may contain ${topic} as a placeholder for the originating '
+         'topic name, e.g. `summit_${topic}`.'
+)
+@click.option(
+    '--tasks', '-t', default=1,
+    help='Number of Kafka Connect tasks.', show_default=True,
+)
+@click.option(
+    '--schema-registry-topic', default='_schemas', show_default=True,
+    help=('The topic that acts as the durable log for the schema registry.')
+)
+@click.option(
+    '--schema-registry-url', default=None, required=True,
+    help=('Comma-separated list of URLs for schema registry instances that '
+          'can be used to register or look up schemas. If the replicator is'
+          ' configured in the destination cluster this should be the URL '
+          ' for the destination schema registry which configured in IMPORT '
+          ' mode.')
+)
+@click.option(
+    '--group-id', default=None,
+    help=('If the replicator needs to run on a separate Connect cluster, '
+          'the `group.id` property specifies which workers to use.')
+)
+@click.option(
+    '--filter', '-f', 'filter_regex', required=True,
+    help='Regex of topics to replicate to the destination cluster.'
+)
+@click.option(
+    '--dry-run', is_flag=True,
+    help=('Show the InfluxDB Sink Connector configuration but does not create '
+          'the connector.')
+)
+@click.option(
+    '--blacklist', 'blacklist', multiple=True,
+    help=('Topics to exclude from replication. Note that Kafka internal '
+          'topics are not replicated by default.')
+)
+@click.option(
+    '--check-interval', 'check_interval', default='120000', show_default=True,
+    help=('How often to poll the source cluster for new topics matching '
+          'the --filer regex, in milliseconds.')
+)
+@click.pass_context
+def create_replicator(ctx, topics, name, src_kafka, dest_kafka,
+                      topic_rename_format, tasks, schema_registry_topic,
+                      schema_registry_url, group_id, filter_regex,
+                      dry_run, blacklist, check_interval):
+    """Create an instance of the Replicator Connector.
+
+    The TOPICS argument specifies the list of topics to replicate. If
+    provided, they are added to the whitelist. If not, only topics matching
+    the --filter regex option will be replicated. Whitelisted topics do not
+    have to match the regex.
+    """
+    topics = list(topics)
+    blacklist = list(blacklist)
+    config = make_replicator_config(topics, src_kafka, dest_kafka,
+                                    topic_rename_format, tasks,
+                                    schema_registry_topic, schema_registry_url,
+                                    group_id, filter_regex, blacklist,
+                                    check_interval)
+    if dry_run:
+        click.echo(json.dumps(config, indent=4, sort_keys=True))
+        return 0
+
+    kafka_connect_url = get_kafka_connect_url(ctx.parent.parent)
+
+    click.echo("Updating the connector...")
+    update_connector(kafka_connect_url, name, config)
+    status = get_connector_status(kafka_connect_url, name)
+    click.echo(status)
+
+
+def make_replicator_config(topics, src_kafka, dest_kafka,
+                           topic_rename_format, tasks,
+                           schema_registry_topic, schema_registry_url,
+                           group_id, filter_regex, blacklist,
+                           check_interval):
+    """Make Replicator connector configuration.
+
+    Parameters
+    ----------
+    topics : `list`
+        List of topics to whitelist.
+    src_kafka : `str`
+        Source Kafka broker.
+    dest_kafka : `str`
+        Destination kafka broker.
+    topic_rename_format : `str`
+        Format string for destination topics, e.g. `summit_$(topic)`.
+    tasks : `int`
+        Number of Kafka connect tasks.
+    schema_registry_url : `str`
+        Schema registry URL for the destination cluster.
+    group_id : `str`
+        Kafka Connect group.id
+    filter_regex : `str`
+        Regex of topics to replicate to the destination cluster.
+    blacklist : `str`
+        Topics to exclude from replication.
+    check_interval : `int`
+        How often to poll the source cluster for new topics.
+    """
+    DEFAULT_CONVERTER = 'io.confluent.connect.replicator.util.'\
+        'ByteArrayConverter'
+    config = {}
+    config['connector.class'] = 'io.confluent.connect.replicator.'\
+        'ReplicatorSourceConnector'
+    config['task.max'] = tasks
+    config['key.converter'] = DEFAULT_CONVERTER
+    config['value.converter'] = DEFAULT_CONVERTER
+    config['header.coverter'] = DEFAULT_CONVERTER
+    config['schema.registry.topic'] = schema_registry_topic
+    config['topic.regex'] = filter_regex
+
+    # Ensure uniqueness and sort topic names
+    topics = list(set(topics))
+    topics.sort()
+
+    # The schema registry topic must be whitelisted explicitly
+    topics.append(schema_registry_topic)
+    config['topic.whitelist'] = ",".join(topics)
+
+    if blacklist:
+        config['topic.blacklist'] = ",".join(blacklist)
+
+    config['topic.rename.format'] = topic_rename_format
+    config['topic.poll.interval.ms'] = check_interval
+    config['src.kafka.bootstrap.servers'] = src_kafka
+    config['dest.kafka.bootstrap.servers'] = dest_kafka
+
+    config['schema.subject.translator.class'] = 'io.confluent.connect.'\
+        'replicator.schemas.DefaultSubjectTranslator'
+
+    config['schema.registry.url'] = schema_registry_url
+
+    if group_id:
+        config['src.consumer.group.id'] = group_id
+
+    return config

--- a/connect_manager/replicator.py
+++ b/connect_manager/replicator.py
@@ -171,7 +171,7 @@ def make_replicator_config(topics, src_kafka, dest_kafka,
     config = {}
     config['connector.class'] = 'io.confluent.connect.replicator.'\
         'ReplicatorSourceConnector'
-    config['task.max'] = tasks
+    config['tasks.max'] = tasks
     config['key.converter'] = DEFAULT_CONVERTER
     config['value.converter'] = DEFAULT_CONVERTER
     config['header.coverter'] = DEFAULT_CONVERTER

--- a/connect_manager/replicator.py
+++ b/connect_manager/replicator.py
@@ -27,6 +27,7 @@ __all__ = ('create_replicator', 'make_replicator_config',)
 
 import click
 import json
+import time
 
 from .utils import (get_kafka_connect_url, update_connector,
                     get_connector_status)
@@ -126,8 +127,14 @@ def create_replicator(ctx, topics, name, src_kafka, dest_kafka,
 
     click.echo("Updating the connector...")
     update_connector(kafka_connect_url, name, config)
-    status = get_connector_status(kafka_connect_url, name)
-    click.echo(status)
+
+    while True:
+        time.sleep(int(check_interval) / 1000)
+        try:
+            status = get_connector_status(kafka_connect_url, name)
+            click.echo(status)
+        except KeyboardInterrupt:
+            raise click.ClickException('Interruped.')
 
 
 def make_replicator_config(topics, src_kafka, dest_kafka,

--- a/cp-kafka-connect/Dockerfile
+++ b/cp-kafka-connect/Dockerfile
@@ -1,0 +1,21 @@
+ARG CONFLUENT_VERSION
+FROM confluentinc/cp-kafka-connect:$CONFLUENT_VERSION
+MAINTAINER afausti@lsst.org
+
+# Add the InfluxDB Sink Connector
+# Download or build the connector from from https://github.com/llensesio/stream-reactor
+ARG STREAM_REACTOR_VERSION
+RUN mkdir -p /etc/landoop/jars/lib
+COPY kafka-connect-influxdb-$STREAM_REACTOR_VERSION-2.1.0-all.jar /etc/landoop/jars/lib
+RUN chmod -R ag+w /etc/landoop/jars/lib
+
+# Add the Oracle JDBC driver for the Confluent JDBC Sink Connector
+# Download the Oracle JDBC driver (ojdbc8.jar) from
+# https://www.oracle.com/technetwork/database/application-development/jdbc/downloads/index.html
+# COPY ./ojdbc8.jar /usr/share/java/kafka-connect-jdbc/
+
+# Add the Replicator Connector
+# Download the corresponding version of the Replicator connector from
+# https://www.confluent.io/hub/confluentinc/kafka-connect-replicator
+RUN mkdir -p /usr/share/java/kafka-connect-replicator
+COPY confluentinc-kafka-connect-replicator-$CONFLUENT_VERSION/lib/* /usr/share/java/kafka-connect-replicator/

--- a/cp-kafka-connect/Makefile
+++ b/cp-kafka-connect/Makefile
@@ -1,0 +1,19 @@
+.PHONY: help cp-kafka-connect
+
+# Version for the specific connectors
+CONFLUENT_VERSION=5.3.1
+STREAM_REACTOR_VERSION=1.2.2-timestamp
+
+# Version for cp-kafka-connect, go along with the version of
+# kafka-connect-manager
+VERSION=0.6.0
+
+help:
+	@echo "Make command reference"
+	@echo "  make docker ....... (make tagged Docker image)"
+
+cp-kafka-connect:
+	docker build --build-arg CONFLUENT_VERSION=$(CONFLUENT_VERSION) \
+	             --build-arg STREAM_REACTOR_VERSION=$(STREAM_REACTOR_VERSION) \
+							 -t lsstsqre/cp-kafka-connect:$(VERSION) .
+	docker push lsstsqre/cp-kafka-connect:$(VERSION)

--- a/cp-kafka-connect/README.rst
+++ b/cp-kafka-connect/README.rst
@@ -1,0 +1,23 @@
+================
+cp-kafka-connect
+================
+
+We build a specific ``cp-kafka-connect`` docker image with the connectors
+managed by ``kafka-connect-manager``.
+
+.. code::
+
+  make cp-kafka-connect
+
+
+Check the ``Makefile`` for the versions of each connector.
+
+InfluxDB Sink connector
+-----------------------
+
+Download or build the connector from `stream-reactor <https://github.com/lsst-sqre/stream-reactor>`_.
+
+Replicator connector
+--------------------
+
+Download the replicator connector from `kafka-connect-replicator <https://www.confluent.io/hub/confluentinc/kafka-connect-replicator>`_.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.7.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/lsst-sqre/kafka-connect-manager',
-    version='0.6.0',
+    version='0.7.0',
     entry_points={
         'console_scripts': ['connect_manager = connect_manager.main:main']
     }

--- a/tests/test_influxdb_sink.py
+++ b/tests/test_influxdb_sink.py
@@ -70,7 +70,7 @@ def test_influxdb_sink_config(config):
     assert config['connect.influx.username'] == 'nobody'
     assert config['connector.class'] == 'com.datamountaineer.streamreactor.'\
         'connect.influx.InfluxSinkConnector'
-    assert config['task.max'] == 1
+    assert config['tasks.max'] == 1
     assert config['topics'] == 'topic1,topic2,topic3'
 
 

--- a/tests/test_influxdb_sink.py
+++ b/tests/test_influxdb_sink.py
@@ -1,0 +1,85 @@
+# This file is part of kafka-connect-manager.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+"""Tests for `kafka-connect-manager` package.
+"""
+
+import pytest
+
+from click.testing import CliRunner
+from connect_manager.influxdb_sink import make_influxdb_sink_config
+from connect_manager.influxdb_sink import update_influxdb_sink_config
+from connect_manager import main
+
+
+@pytest.fixture
+def config():
+    """Fixture to return the influxdb-sink configuration given a set of
+    input values.
+    """
+    influxdb_url = 'https://example.com'
+    database = 'mydb'
+    tasks = 1
+    username = 'nobody'
+    password = None
+    error_policy = 'NOOP'
+    max_retries = '1'
+    retry_interval = '1000'
+    config = make_influxdb_sink_config(influxdb_url,
+                                       database, tasks, username,
+                                       password, error_policy,
+                                       max_retries, retry_interval)
+    topics = ['topic1', 'topic2', 'topic3']
+    timestamp = 'mytime'
+    config = update_influxdb_sink_config(config, topics, timestamp)
+
+    return config
+
+
+def test_influxdb_sink_config(config):
+    """ Test influxdb-sink config """
+
+    assert config['connect.influx.db'] == 'mydb'
+    assert config['connect.influx.error.policy'] == 'NOOP'
+    assert config['connect.influx.kcql'] == 'INSERT INTO topic1 SELECT * FROM'\
+        ' topic1 WITHTIMESTAMP mytime;INSERT INTO topic2 SELECT * FROM topic2'\
+        ' WITHTIMESTAMP mytime;INSERT INTO topic3 SELECT * FROM topic3'\
+        ' WITHTIMESTAMP mytime'
+    assert config['connect.influx.max.retries'] == '1'
+    assert config['connect.influx.retry.interval'] == '1000'
+    assert config['connect.influx.url'] == 'https://example.com'
+    assert config['connect.influx.username'] == 'nobody'
+    assert config['connector.class'] == 'com.datamountaineer.streamreactor.'\
+        'connect.influx.InfluxSinkConnector'
+    assert config['task.max'] == 1
+    assert config['topics'] == 'topic1,topic2,topic3'
+
+
+def test_influxdb_sink_cli():
+    """Test the CLI for the influxdb-sink subcommand."""
+    runner = CliRunner()
+    create_result = runner.invoke(main.main, ['create'])
+    assert create_result.exit_code == 0
+    assert 'influxdb-sink' in create_result.output
+    create_influxdb_sink_result = runner.invoke(main.main,
+                                                ['create influxdb-sink'])
+    assert create_influxdb_sink_result.exit_code == 2

--- a/tests/test_replicator.py
+++ b/tests/test_replicator.py
@@ -71,7 +71,7 @@ def test_replicator_config(config):
     assert config['schema.subject.translator.class'] == 'io.confluent.connect'\
         '.replicator.schemas.DefaultSubjectTranslator'
     assert config['src.kafka.bootstrap.servers'] == 'localhost:80'
-    assert config['task.max'] == 4
+    assert config['tasks.max'] == 4
     assert config['topic.poll.interval.ms'] == '1000'
     assert config['topic.rename.format'] == '${topic}'
     assert config['topic.regex'] == 'topic*'

--- a/tests/test_replicator.py
+++ b/tests/test_replicator.py
@@ -1,0 +1,93 @@
+# This file is part of kafka-connect-manager.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+"""Tests for `kafka-connect-manager` package.
+"""
+
+import pytest
+
+from click.testing import CliRunner
+from connect_manager.replicator import make_replicator_config
+from connect_manager import main
+
+
+@pytest.fixture
+def config():
+    """Fixture to return the replicator configuration given a set of
+    input values.
+    """
+    topics = ['t1', 'topic2', 'topic3']
+    blacklist = ['topic2']
+    src_kafka = 'localhost:80'
+    dest_kafka = 'localhost:80'
+    topic_rename_format = '${topic}'
+    tasks = 4
+    schema_registry_topic = '_schemas'
+    schema_registry_url = 'http://example.com'
+    group_id = None
+    filter_regex = 'topic*'
+    check_interval = '1000'
+
+    config = make_replicator_config(topics, src_kafka, dest_kafka,
+                                    topic_rename_format, tasks,
+                                    schema_registry_topic,
+                                    schema_registry_url, group_id,
+                                    filter_regex, blacklist, check_interval)
+    return config
+
+
+def test_replicator_config(config):
+    """ Test replicator config """
+
+    DEFAULT_CONVERTER = 'io.confluent.connect.replicator.util.'\
+                        'ByteArrayConverter'
+
+    assert config['connector.class'] == 'io.confluent.connect.replicator.'\
+        'ReplicatorSourceConnector'
+    assert config['dest.kafka.bootstrap.servers'] == 'localhost:80'
+    assert config['header.coverter'] == DEFAULT_CONVERTER
+    assert config['key.converter'] == DEFAULT_CONVERTER
+    assert config['schema.registry.topic'] == '_schemas'
+    assert config['schema.registry.url'] == 'http://example.com'
+    assert config['schema.subject.translator.class'] == 'io.confluent.connect'\
+        '.replicator.schemas.DefaultSubjectTranslator'
+    assert config['src.kafka.bootstrap.servers'] == 'localhost:80'
+    assert config['task.max'] == 4
+    assert config['topic.poll.interval.ms'] == '1000'
+    assert config['topic.rename.format'] == '${topic}'
+    assert config['topic.regex'] == 'topic*'
+    # Make sure blacklisted 'topic2' is not whitelisted
+    assert config['topic.blacklist'] == 'topic2'
+    # Whitelisted topics do not have to match the regex
+    assert config['topic.whitelist'] == 't1,topic3,_schemas'
+    assert config['value.converter'] == DEFAULT_CONVERTER
+
+
+def test_replicator_cli():
+    """Test the CLI for the replicator subcommand."""
+    runner = CliRunner()
+    create_result = runner.invoke(main.main, ['create'])
+    assert create_result.exit_code == 0
+    assert 'replicator' in create_result.output
+    create_replicator_result = runner.invoke(main.main,
+                                             ['create replicator'])
+    assert create_replicator_result.exit_code == 2


### PR DESCRIPTION
- Refactor influxdb.py to reuse code for the replicator connector
- Add support for the replicator connector
- Add initial tests using ``pytest`` fixtures