### PR TITLE
[DM-30662] Test new array handling support in the Lenses InfluxDB Sink connector

### DIFF
--- a/cp-kafka-connect/Dockerfile
+++ b/cp-kafka-connect/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER afausti@lsst.org
 
 # Add the InfluxDB Sink Connector
 # Download kafka-connect-influxdb from
-# https://github.com/lsst-sqre/stream-reactor/releases/tag/1.2.2-tickets-DM-21334
+# https://github.com/lsst-sqre/stream-reactor/releases/tag/2.1.3-array-support
 
 RUN mkdir -p /etc/landoop/jars/lib
-COPY kafka-connect-influxdb-1.2.2-tickets-DM-21334.jar /etc/landoop/jars/lib
+COPY kafka-connect-influxdb-2.1.3-2.5.0-all.jar /etc/landoop/jars/lib
 RUN chmod -R ag+w /etc/landoop/jars/lib

--- a/cp-kafka-connect/Makefile
+++ b/cp-kafka-connect/Makefile
@@ -5,7 +5,7 @@ CONFLUENT_VERSION=5.5.2
 
 # Version for cp-kafka-connect, go along with the version of
 # kafka-connect-manager
-VERSION=0.9-tickets-DM-21334
+VERSION=0.9.1
 
 help:
 	@echo "Make command reference"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   kafkaconnect:
-    image: lsstsqre/kafkaconnect:0.9.0
+    image: lsstsqre/kafkaconnect:0.9.1
     container_name: kafkaconnect
     entrypoint: kafkaconnect
     environment:
@@ -56,7 +56,7 @@ services:
 
 
   connect:
-    image: lsstsqre/cp-kafka-connect:5.5.2-0.8.2-tickets-DM-21334
+    image: lsstsqre/cp-kafka-connect:5.5.2-0.9.1
     hostname: connect
     container_name: connect
     depends_on:


### PR DESCRIPTION
- Update` kafka-connect-influxdb` to `2.1.3-array-support` tag  and scripts to build `cp-kafka-connect` image.