### PR TITLE
[DM-30654] Release Kafka-connect-manager 0.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # VSCode editor settings
 .vscode
+
+# MacOS
+.DS_Store

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Change log
 ##########
 
+0.9.1 (2021-06-09)
+==================
+
+* Add support to configure multiple InfluxDB Sink connectors.
+* Add user guide documentation on how to reset the InfluxDB Sink connector consumer group offsets.
+* Update ``cp-kafka-connect`` image with new version of the InfluxDB Sink Connector. See `#737 <https://github.com/lensesio/stream-reactor/issues/737>`_ for details.
+
 0.9.0 (2021-05-03)
 ==================
 
@@ -13,7 +20,7 @@ Change log
 0.8.3 (2021-03-04)
 ==================
 
-* Add upload command 
+* Add upload command
 * Initial support to MirrorMaker 2 and Confuent JDBC Sink Connectors
 * Update dependencies
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -87,7 +87,7 @@ Note that in this command we used <TAB> as the default separator for key and val
 Recording arrays in InfluxDB
 ----------------------------
 
-The connector supports Avro type array, it extracts the elements of the array into individual fields in InfluxDB of the same type:
+InfluxDB does not support array fields, the connector handles arrays in Avro by flattening them before writing to InfluxDB. The following command produce an Avro message with type array:
 
 .. code-block:: bash
 
@@ -95,7 +95,7 @@ The connector supports Avro type array, it extracts the elements of the array in
   {"bar": "John Doe","baz": [1,2,3]}
   Ctrl+D
 
-which in InfluxDB is stored like:
+which is stored in InfluxDB like:
 
 .. code-block:: bash
 
@@ -104,3 +104,65 @@ which in InfluxDB is stored like:
   time                bar      baz0 baz1 baz2
   ----                ---      ---- ---- ----
   1611707507555316950 John Doe 1    2    3
+
+
+Resetting consumer group offsets
+================================
+
+When a sink connector is created, a consumer group keeps track of the offsets of each topic configured in the connector.
+From the InfluxDB Sink connector created above, the following command list the consumer groups.
+
+.. code-block:: bash
+
+  docker-compose exec broker kafka-consumer-groups --bootstrap-server localhost:9092 --list
+  connect-influxdb-sink
+
+The topic offset for the ``connect-influxdb-sink`` consumer group is shown using:
+
+.. code-block:: bash
+
+  docker-compose exec broker kafka-consumer-groups --bootstrap-server localhost:9092  --describe --offsets  --group connect-influxdb-sink
+
+  GROUP                 TOPIC           PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG             CONSUMER-ID                                                             HOST            CLIENT-ID
+  connect-influxdb-sink foo             0          1               1               0               connector-consumer-influxdb-sink-0-896a850d-4cbc-406c-a0c6-afcc7fb31da5 /192.168.80.6   connector-consumer-influxdb-sink-0
+
+The log-end-offset is the offset of the last message sent to Kafka, and the current-offset is the offset of the last message consumed by the connector.
+The difference is the consumer lag.
+In the example, the connector is configured with only one topic ``foo``, and the only message produced was consumed by the connector.
+
+It is possible to force the connector to consume the messages produced to the ``foo`` topic again by resetting the consumer group offsets.
+
+The following commands will make the connector to write the messages to InfluxDB again, by resetting the consumer group offsets to the earliest offset available in Kafka.
+
+First we check the consumer group state:
+
+.. code-block:: bash
+
+  docker-compose exec broker kafka-consumer-groups --bootstrap-server localhost:9092 --group connect-influxdb-sink --describe --state
+
+  GROUP                     COORDINATOR (ID)          ASSIGNMENT-STRATEGY  STATE           #MEMBERS
+  connect-influxdb-sink     localhost:9092 (1)        range                Stable          1
+
+To reset offsets wee need to change the consumer group state to ``Empty``.
+To do that we delete the connector that is using the consumer group.
+
+.. code-block:: bash
+
+  docker-compose run kafkaconnect delete influxdb-sink
+
+Now we reset the consumer group offsets:
+
+.. code-block:: bash
+
+  docker-compose exec broker kafka-consumer-groups --bootstrap-server localhost:9092 --group connect-influxdb-sink --topic foo --reset-offsets --to-earliest --execute
+
+  GROUP                          TOPIC                          PARTITION  NEW-OFFSET
+  connect-influxdb-sink          foo                            0          0
+
+And finally recreate the connector:
+
+.. code-block:: bash
+
+  docker-compose run kafkaconnect create influxdb-sink -d mydb foo
+
+When deploying multiple InfluxDB Sink connectors consuming the same topics, a possible scenario is to configure one connector consuming the earliest offsets to recover historical data from Kafka into InfluxDB ("repairer" connector), and a second connector consuming the latest offsets to keep up with the current data in InfluxDB.


### PR DESCRIPTION
- Add support to configure multiple InfluxDB Sink connectors.
- Add user guide documentation on how to reset the InfluxDB Sink connector consumer group offsets.
- Update cp-kafka-connect image with new version of the InfluxDB Sink Connector. See #737 for details.
