### PR TITLE
[DM-35511] Update strimzi-kafka image build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
           push: true
           tags: |
             lsstsqre/kafkaconnect:${{ steps.vars.outputs.tag }}
-            ghci.io/lsst-sqre/kafkaconnect:${{ steps.vars.outputs.tag }}
+            ghcr.io/lsst-sqre/kafkaconnect:${{ steps.vars.outputs.tag }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
 

--- a/.github/workflows/strimzi-kafka.yaml
+++ b/.github/workflows/strimzi-kafka.yaml
@@ -41,8 +41,7 @@ jobs:
 
       - name: Download and extract the InfluxDB Sink Connector plugin
         run: |
-          curl -LO https://github.com/lensesio/stream-reactor/releases/download/3.0.1/kafka-connect-influxdb-3.0.1-2.5.0-all.tar.gz
-          tar xvzf kafka-connect-influxdb-3.0.1-2.5.0-all.tar.gz
+          curl -LO https://github.com/lsst-sqre/stream-reactor/releases/download/Tim/kafka-connect-influxdb-3.0.1-timestampunit.jar
         working-directory: ./strimzi-kafka
 
       - name: Set up Docker Buildx
@@ -67,7 +66,7 @@ jobs:
           context: strimzi-kafka
           push: true
           tags: |
-            lsstsqre/strimzi-0.27.1-kafka-3.0.0:${{ steps.vars.outputs.tag }}
-            ghcr.io/lsst-sqre/strimzi-0.27.1-kafka-3.0.0:${{ steps.vars.outputs.tag }}
+            lsstsqre/strimzi-0.29.0-kafka-3.1.1:${{ steps.vars.outputs.tag }}
+            ghcr.io/lsst-sqre/strimzi-0.29.0-kafka-3.1.1:${{ steps.vars.outputs.tag }}
           cache-from: type=gha,scope=strimzi-kafka
           cache-to: type=gha,mode=max,scope=strimzi-kafka

--- a/strimzi-kafka/Dockerfile
+++ b/strimzi-kafka/Dockerfile
@@ -1,6 +1,6 @@
 # Build strimzi-kafka image with the influxdb connector plugin
-FROM quay.io/strimzi/kafka:0.27.1-kafka-3.0.0
+FROM quay.io/strimzi/kafka:0.29.0-kafka-3.1.1
 USER root:root
-COPY kafka-connect-influxdb-3.0.1-2.5.0-all.jar /opt/kafka/plugins/
+COPY kafka-connect-influxdb-3.0.1-timestampunit.jar /opt/kafka/plugins/
 RUN chmod -R ag+w /opt/kafka/plugins
 USER 1001


### PR DESCRIPTION
- Update base image to tag 0.29.0-kafka-3.1.1
- Build image with kafka-connect-influxdb-3.0.1-timestampunit.jar plugin